### PR TITLE
fix: consider 30X as successful HTTP status code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "symfony/http-kernel": "^3.0",
         "symfony/serializer": "^3.0",
         "symfony/property-access": "^3.0",
+        "symfony/yaml": "^3.0",
         "jrfnl/PHP-cast-to-type": "^2.0",
         "willdurand/negotiation": "^2.0",
         "ralouphie/getallheaders": "^2.0",
@@ -27,13 +28,13 @@
     },
     "suggest": {
         "silex/silex": "To use the Silex Router",
-        "alecsammon/php-raml-parser": "To use the RAML APISpec"
+        "raml-org/raml-php-parser": "To use the RAML APISpec"
     },
     "require-dev": {
         "atoum/atoum": "^3.0",
         "atoum/stubs": "*",
         "silex/silex": "^2.0",
-        "alecsammon/php-raml-parser": "^2.2",
+        "raml-org/raml-php-parser": "^2.2",
         "friendsofphp/php-cs-fixer": "^2.0",
         "squizlabs/php_codesniffer": "^2.0",
         "atoum/reports-extension": "^3.0"

--- a/src/RREST.php
+++ b/src/RREST.php
@@ -220,12 +220,11 @@ class RREST
     protected function getStatusCodeSuccess()
     {
         $statusCodes = $this->apiSpec->getStatusCodes();
-        //find a 20x code
-        $statusCodes20x = array_filter($statusCodes, function ($value) {
-            return preg_match('/20\d?/', $value);
+        $successfulStatusCodes = array_filter($statusCodes, function ($value) {
+            return preg_match('/^[23]0\d?$/', $value);
         });
-        if (count($statusCodes20x) === 1) {
-            return (int) array_pop($statusCodes20x);
+        if (count($successfulStatusCodes) === 1) {
+            return (int) array_pop($successfulStatusCodes);
         } else {
             throw new \RuntimeException('You can\'t define multiple 20x for one resource path!');
         }


### PR DESCRIPTION
change RREST to consider a 30X HTTP status code as a successful code.

(The test are failing on my local setup (?), so waiting for Travis to validate)