### PR TITLE
feat: add partial support text/csv response

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,10 @@ Based on the APISpec description, **RREST** validate i/o:
 `Accept` is required for every request.  
 `Content-Type` is required for `POST` & `PUT` method.
 
-> **RREST** only support JSON & XML for input/output, so valid mime-types are: `application/json`, `application/x-json`, `text/xml`, `application/xml` & `application/x-xml`.
+> **RREST** supports JSON & XML for input/output and partially supports CSV for
+> output, so valid mime-types are: `application/json`, `application/x-json`,
+> `text/xml`, `application/xml`, `application/x-xml`, 'text/csv' and
+> 'application/csv'.
 
 #### Protocol
 
@@ -103,6 +106,7 @@ This will ensure that data input is valid.
 Depending of the `Accept` header, **RREST** will validate:
 * if the format (`JSON`or `XML`) is valid
 * if it follow the schema (`JSON Schema` or `XML Schema`)
+* there's no validation for `CSV`
 
 A schema is not required by **RREST** for a response. But this is a security to be sure that your response
 respect your APISpec and your documentation based on it.
@@ -188,6 +192,7 @@ class Resource
 ##### Format input/output
 * JSON
 * XML
+* CSV (output only)
 
 ##### APISPec
 * RAML

--- a/src/RREST.php
+++ b/src/RREST.php
@@ -23,6 +23,7 @@ class RREST
     public static $supportedMimeTypes = [
         'json' => ['application/json', 'application/x-json'],
         'xml' => ['text/xml', 'application/xml', 'application/x-xml'],
+        'csv' => ['text/csv', 'application/csv'],
     ];
 
     /**

--- a/src/Response.php
+++ b/src/Response.php
@@ -36,7 +36,7 @@ class Response
     /**
      * @var string[]
      */
-    protected $supportedFormat = ['json', 'xml'];
+    protected $supportedFormat = ['json', 'xml', 'csv'];
 
     /**
      * @var RouterInterface
@@ -251,6 +251,14 @@ class Response
             $data = json_decode(json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE), true);
 
             return $serializer->serialize($data, $format);
+        } elseif ($format === 'csv') {
+            if (!is_string($data)) {
+                throw new \RuntimeException(
+                    'auto serialization for CSV format is not supported'
+                );
+            }
+
+            return $data;
         } else {
             throw new \RuntimeException(
                 'format not supported, only are '.implode(', ', $this->supportedFormat).' availables'
@@ -279,6 +287,9 @@ class Response
                 break;
             case strpos($format, 'xml') !== false:
                 $this->assertResponseXML($value, $schema);
+                break;
+            case strpos($format, 'csv') !== false:
+                // no validation for CSV
                 break;
             default:
                 throw new \RuntimeException(

--- a/tests/units/Response.php
+++ b/tests/units/Response.php
@@ -93,6 +93,34 @@ class Response extends atoum
         ;
     }
 
+    public function testNoCsvSerialize()
+    {
+        $this->newTestedInstance($this->router, 'csv', 200);
+
+        $this
+            ->given($this->testedInstance)
+            ->exception(
+                function () {
+                    $this->testedInstance->serialize([], 'csv');
+                }
+            )
+            ->isInstanceOf('\RuntimeException')
+            ->message->contains('auto serialization for CSV format is not supported');
+    }
+
+    public function testSerializeForCsv()
+    {
+        $this->newTestedInstance($this->router, 'csv', 200);
+
+        $csv = "The Black Keys;El Camino\nFoo Fighters;Sonic Highways";
+
+        $this
+            ->given($this->testedInstance)
+            ->string($this->testedInstance->serialize($csv, 'csv'))
+            ->isEqualTo($csv);
+        ;
+    }
+
     public function testAssertReponseSchema()
     {
         $this->newTestedInstance($this->router, 'json', 200);


### PR DESCRIPTION
this adds the ability to set `Accept: text/csv` in a request. The support is partial because:

1. there's no validation mechanism of CSV Response content
1. auto serialization is not supported
1. `text/csv` is not supported in request body