### PR TITLE
WIP: feat(Response): add file property to Response object to be able to serve files

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -21,6 +21,11 @@ class Response
     /**
      * @var string
      */
+    protected $file;
+
+    /**
+     * @var string
+     */
     protected $format;
 
     /**
@@ -60,6 +65,14 @@ class Response
         $this->setFormat($format);
         $this->setRouter($router);
         $this->setStatusCode($statusCode);
+    }
+
+    /**
+     * @param string
+     */
+    public function setFile($file)
+    {
+        $this->file = $file;
     }
 
     /**
@@ -226,7 +239,7 @@ class Response
         }
 
         return $this->router->getResponse(
-            $content, $this->getConfiguredHeaderstatusCode(), $this->getConfiguredHeaders()
+            $content, $this->getConfiguredHeaderstatusCode(), $this->getConfiguredHeaders(), $this->file
         );
     }
 

--- a/src/Router/RouterInterface.php
+++ b/src/Router/RouterInterface.php
@@ -55,8 +55,9 @@ interface RouterInterface
      * @param string   $content
      * @param int      $statusCode
      * @param string[] $headers
+     * @param string|null $file
      *
      * @return mixed
      */
-    public function getResponse($content = '', $statusCode = 200, $headers = array());
+    public function getResponse($content = '', $statusCode = 200, $headers = array(), $file = null);
 }

--- a/src/Router/Silex.php
+++ b/src/Router/Silex.php
@@ -2,6 +2,7 @@
 
 namespace RREST\Router;
 
+use Symfony\Component\HttpFoundation\BinaryFileResponse as HttpFoundationBinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response as HttpFoundationResponse;
 use RREST\Response;
@@ -111,8 +112,11 @@ class Silex implements RouterInterface
     /**
      * {@inheritdoc}
      */
-    public function getResponse($content = '', $statusCode = 200, $headers = array())
+    public function getResponse($content = '', $statusCode = 200, $headers = array(), $file = null)
     {
+        if (!empty($file)) {
+            return new HttpFoundationBinaryFileResponse($file, $statusCode, $headers);
+        }
         return new HttpFoundationResponse($content, $statusCode, $headers);
     }
 }

--- a/tests/units/Response.php
+++ b/tests/units/Response.php
@@ -215,4 +215,17 @@ class Response extends atoum
             ->isEqualTo('https://api.domain.com/items/uuid')
         ;
     }
+
+    public function testGetRouterResponseWithFile()
+    {
+        $this->newTestedInstance($this->router, 'json', 201);
+
+        $this
+            ->given($this->testedInstance)
+            ->and(
+                $this->testedInstance->setFile(__DIR__.'/../fixture/song.xml')
+            )
+            ->object($this->testedInstance->getRouterResponse())
+            ->isInstanceOf('Symfony\Component\HttpFoundation\BinaryFileResponse');
+    }
 }

--- a/tests/units/Router/Silex.php
+++ b/tests/units/Router/Silex.php
@@ -54,6 +54,15 @@ class Silex extends atoum
             ->isInstanceOf('Symfony\Component\HttpFoundation\Response');
     }
 
+    public function testGetResponseWithFile()
+    {
+        $this->newTestedInstance($this->app);
+        $this
+            ->given($this->testedInstance)
+            ->object($this->testedInstance->getResponse('XXX', 200, [], __DIR__.'/../../fixture/song.xml'))
+            ->isInstanceOf('Symfony\Component\HttpFoundation\BinaryFileResponse');
+    }
+
     public function testGetPayloadBodyValue()
     {
         $this->newTestedInstance($this->app);


### PR DESCRIPTION
Purpose is to be able to serve files with RREST.  
This PR proposes to add a `Response::file`property. If this property is set, the `Router::getResponse()` method will return a `HttpFoundation\BinaryFileResponse`, instead of a simple `HttpFoundation\Response`.  
The detailled configuration of the BinaryFileResponse is expected to be done afterward, by the client. (headers, deleteFileAfterSend, etc...)