### PR TITLE
Composer cleanup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,11 @@
         "willdurand/negotiation": "^2.0",
         "ralouphie/getallheaders": "^2.0",
         "league/json-guard": "^1.0",
-        "league/json-reference": "^1.0"
+        "league/json-reference": "^1.0",
+        "ext-libxml": "*",
+        "ext-dom": "*",
+        "ext-json": "*",
+        "ext-simplexml": "*"
     },
     "suggest": {
         "silex/silex": "To use the Silex Router",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/serializer": "^3.0",
         "symfony/property-access": "^3.0",
         "symfony/yaml": "^3.0",
-        "jrfnl/PHP-cast-to-type": "^2.0",
+        "jrfnl/php-cast-to-type": "^2.0",
         "willdurand/negotiation": "^2.0",
         "ralouphie/getallheaders": "^2.0",
         "league/json-guard": "^1.0",


### PR DESCRIPTION
Small fixes in `composer.json`:
- Fixed a package name that was not in lower case.
- Added missing needed php extension.