### PR TITLE
Require php 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     },
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.0",
         "symfony/http-kernel": "^3.0",
         "symfony/serializer": "^3.0",
         "symfony/property-access": "^3.0",


### PR DESCRIPTION
As we are working on a v2.0 that breaks BC. This is an opportunity to bump php to a more modern version.

That will allow us to use some of the feature coming with it such as a better typehinting.