### PR TITLE
Minimal compatibility with RAML 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@
 ## Versions
 > Important: **RREST 2.0** is in active development. It doesn't cover RAML 1.0 completely.
 
+### RAML 1.0
+RAML 1.0 is not covered completely.
+
+Known missing feature:
+- Support date format that are not `datetime`.
+
+Limitations of RAML handling can be found in its [Parameter handling](https://github.com/RETFU/RREST/blob/master/src/Parameter.php).
+
+### RAML 0.8
 For usage with RAML 0.8 please use RREST v1.x versions.
 
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/serializer": "^3.0",
         "symfony/property-access": "^3.0",
         "symfony/yaml": "^3.0",
-        "raml-org/raml-php-parser": "^2.2",
+        "raml-org/raml-php-parser": "^4.6",
         "jrfnl/php-cast-to-type": "^2.0",
         "willdurand/negotiation": "^2.0",
         "ralouphie/getallheaders": "^2.0",

--- a/src/APISpec/RAML.php
+++ b/src/APISpec/RAML.php
@@ -2,6 +2,8 @@
 
 namespace RREST\APISpec;
 
+use Raml\BodyInterface;
+use Raml\WebFormBody;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Raml\ApiDefinition;
@@ -36,7 +38,7 @@ class RAML implements APISpecInterface
     /**
      * @param ApiDefinition $apiDefinition
      * @param string        $httpMethod
-     * @param strings       $routePath     (PHP_URL_PATH)
+     * @param string       $routePath     (PHP_URL_PATH)
      */
     public function __construct(ApiDefinition $apiDefinition, $httpMethod, $routePath)
     {
@@ -173,12 +175,23 @@ class RAML implements APISpecInterface
         $bodies = $this->method->getBodies();
         if (empty($bodies) === false) {
             try {
-                return (string) $this->method->getBodyByType($contentType)->getSchema();
+                $body = $this->method->getBodyByType($contentType);
+
+                if ($this->hasSchema($body)) {
+                    return (string)$body->getSchema();
+                }
+
+                return '';
             } catch (\Exception $e) {
             }
         }
 
         return false;
+    }
+
+    private function hasSchema(BodyInterface $body): bool
+    {
+        return !($body instanceof WebFormBody);
     }
 
     /**

--- a/src/Parameter.php
+++ b/src/Parameter.php
@@ -6,23 +6,29 @@ use RREST\Exception\InvalidParameterException;
 
 class Parameter
 {
-    const TYPE_STRING = 'string';
     const TYPE_NUMBER = 'number';
-    const TYPE_INTEGER = 'integer';
-    const TYPE_DATE = 'date';
     const TYPE_BOOLEAN = 'boolean';
+    const TYPE_STRING = 'string';
+    const TYPE_DATE_ONLY = 'date-only';
+    const TYPE_TIME_ONLY = 'time-only';
+    const TYPE_DATETIME_ONLY = 'datetime-only';
+    const TYPE_DATETIME = 'datetime';
     const TYPE_FILE = 'file';
+    const TYPE_INTEGER = 'integer';
 
     /**
      * @var string[]
      */
     protected $validTypes = [
-        self::TYPE_STRING,
         self::TYPE_NUMBER,
-        self::TYPE_INTEGER,
-        self::TYPE_DATE,
+        self::TYPE_STRING,
         self::TYPE_BOOLEAN,
+        self::TYPE_DATE_ONLY,
+        self::TYPE_TIME_ONLY,
+        self::TYPE_DATETIME_ONLY,
+        self::TYPE_DATETIME,
         self::TYPE_FILE,
+        self::TYPE_INTEGER,
     ];
 
     /**
@@ -266,10 +272,17 @@ class Parameter
                     $this->throwInvalidParameter($this->getName().' is not a boolean');
                 }
                 break;
-            case static::TYPE_DATE:
+            case static::TYPE_DATETIME:
                 if ($value instanceof \DateTime === false) {
                     $this->throwInvalidParameter($this->getName().' is not a valid date');
                 }
+                break;
+            case static::TYPE_DATE_ONLY:
+            case static::TYPE_TIME_ONLY:
+            case static::TYPE_DATETIME_ONLY:
+                $this->throwInvalidParameter(
+                    $this->getType().' is not supported yet in RREST. Use datetime or feel free to contribute it'
+                );
                 break;
             case static::TYPE_STRING:
                 if (!is_string($value)) {

--- a/src/RREST.php
+++ b/src/RREST.php
@@ -418,7 +418,7 @@ class RREST
             $type = 'num';
         }
 
-        if ($type != 'date') {
+        if ($type != 'datetime') {
             $castValue = \CastToType::cast($value, $type, false, true);
         } else {
             //Specific case for date

--- a/tests/fixture/song.raml
+++ b/tests/fixture/song.raml
@@ -1,4 +1,4 @@
-#%RAML 0.8
+#%RAML 1.0
 
 title: World Music API
 baseUri: http://{bucketName}.api.com/{version}
@@ -9,7 +9,7 @@ baseUriParameters:
     required: false
 version: v1
 securitySchemes:
-    - JWT:
+    JWT:
         description: |
             https://jwt.io/introduction/
         type: x-jwt
@@ -23,9 +23,9 @@ securitySchemes:
                         ```
                     type: string
                     required: true
-schemas:
-  - Song: !include song.json
-  - Person: |
+types:
+  Song: !include song.json
+  Person: |
       {
         "$schema": "http://json-schema.org/schema",
         "type": "array",
@@ -95,10 +95,9 @@ schemas:
           choice[]:
               description: Filter by choice
               type: string
-              repeat: true
           modificationDate:
               description: Modification date
-              type: date
+              type: datetime
       responses:
         200:
           body:

--- a/tests/units/Parameter.php
+++ b/tests/units/Parameter.php
@@ -126,8 +126,50 @@ class Parameter extends atoum
             ->isInstanceOf('RREST\Exception\InvalidParameterException')
         ;
 
-        //cast type date
-        $this->newTestedInstance('name', 'date', true);
+        //cast type datetime
+        $this->newTestedInstance('name', 'datetime', true);
+        $this
+            ->exception(
+                function () {
+                    $this
+                        ->testedInstance
+                        ->assertValue('test', 'test')
+                    ;
+                }
+            )
+            ->isInstanceOf('RREST\Exception\InvalidParameterException')
+        ;
+
+        //cast type date-only
+        $this->newTestedInstance('name', 'date-only', true);
+        $this
+            ->exception(
+                function () {
+                    $this
+                        ->testedInstance
+                        ->assertValue('test', 'test')
+                    ;
+                }
+            )
+            ->isInstanceOf('RREST\Exception\InvalidParameterException')
+        ;
+
+        //cast type time-only
+        $this->newTestedInstance('name', 'time-only', true);
+        $this
+            ->exception(
+                function () {
+                    $this
+                        ->testedInstance
+                        ->assertValue('test', 'test')
+                    ;
+                }
+            )
+            ->isInstanceOf('RREST\Exception\InvalidParameterException')
+        ;
+
+        //cast type datetime-only
+        $this->newTestedInstance('name', 'datetime-only', true);
         $this
             ->exception(
                 function () {


### PR DESCRIPTION
The goal of this MR is to be able to use RAML 1.0 having a 0.8 schema and the minimal modification.

The main change here are:
- `date` in 0.8 is now `datetime` and they are various new date format that I did not implement (only added userfriendly errors and documentation).
- When using `multipart/form-data` there is no schema, so I added a workaround to make the code still work without major refactoring.

## Performances
No real difference noticed.

Also the test suite of this project runs at the exact same speed.
