### PR TITLE
Updated supported php versions in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2
-  - hhvm
+  - 7.3
+  - 7.4
   - nightly
 
 before_script:
@@ -17,4 +17,3 @@ script:
 matrix:
   allow_failures:
     - php: nightly
-    - php: hhvm


### PR DESCRIPTION
We bumped php version so it failed in php 5.6 on master: https://travis-ci.org/github/RETFU/RREST/builds/699643538

This MR removes PHP 5.6 and HHVM. It adds PHP 7.3 and 7.4.