### PR TITLE
Allow failure on 7.4 (for now)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,5 @@ script:
 
 matrix:
   allow_failures:
+    - php: 7.4
     - php: nightly


### PR DESCRIPTION
At the moment, it fails on 7.4 because of depreciation errors.

Since it was not tested before, I allow failures until we fix it cleanly.