### PR TITLE
fix(typehint): typo on param type

### DIFF
--- a/src/APISpec/RAML.php
+++ b/src/APISpec/RAML.php
@@ -36,7 +36,7 @@ class RAML implements APISpecInterface
     /**
      * @param ApiDefinition $apiDefinition
      * @param string        $httpMethod
-     * @param strings       $routePath     (PHP_URL_PATH)
+     * @param string        $routePath     (PHP_URL_PATH)
      */
     public function __construct(ApiDefinition $apiDefinition, $httpMethod, $routePath)
     {


### PR DESCRIPTION
The wrong typehint is bugging the static analyser.