### PR TITLE
fix(Parameter): allow required boolean with value false

### DIFF
--- a/src/Parameter.php
+++ b/src/Parameter.php
@@ -257,7 +257,7 @@ class Parameter
     public function assertValue($value)
     {
         // required?
-        if (empty($value)) {
+        if (!$this->hasValue($value)) {
             if ($this->getRequired()) {
                 $this->throwInvalidParameter($this->getName().' is required');
             }
@@ -360,5 +360,21 @@ class Parameter
         throw new InvalidParameterException([
             new Error($message, 'parameter-invalid'),
         ]);
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function hasValue($value): bool
+    {
+        return !empty($value) || $this->isBooleanWithValueFalse($value);
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function isBooleanWithValueFalse($value): bool
+    {
+        return $this->getType() === self::TYPE_BOOLEAN && is_bool($value) && $value === false;
     }
 }

--- a/tests/units/Parameter.php
+++ b/tests/units/Parameter.php
@@ -250,4 +250,14 @@ class Parameter extends atoum
             ->isInstanceOf('\RuntimeException')
         ;
     }
+
+    public function testAssertValueOnMandatoryFalseBoolean()
+    {
+        $this->newTestedInstance('name', 'boolean', true);
+        $this
+            ->given($this->testedInstance)
+            ->variable($this->testedInstance->assertValue(false))
+            ->isNull
+        ;
+    }
 }


### PR DESCRIPTION
A boolean false is considered as an "empty" value, so if this parameter is required, it will throw an exception

Fix this by checking the type and the value of the parameter