### PR TITLE
refactor(exception): Add abstract class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
             "test -d .git && cp contrib/pre-commit .git/hooks/pre-commit",
             "test -d .git && chmod +x .git/hooks/pre-commit"
         ],
-        "cs": "php-cs-fixer fix --config=.php_cs"
+        "cs": "php-cs-fixer fix --config=.php_cs",
+        "test": "atoum"
     }
 }

--- a/src/Exception/ErrorException.php
+++ b/src/Exception/ErrorException.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RREST\Exception;
+
+use RREST\Error;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+abstract class ErrorException extends HttpException
+{
+    /**
+     * @var Error[]
+     */
+    public $errors;
+
+    /**
+     * @param Error[] $errors
+     */
+    public function __construct(array $errors, int $statusCode, string $message = null, \Throwable $previous = null, array $headers = [], int $code = 0)
+    {
+        $this->errors = $errors;
+
+        parent::__construct($statusCode, $message, $previous, $headers, $code);
+    }
+
+    /**
+     * @return Error[]
+     */
+    public function getErrors()
+    {
+        return $this->errors;
+    }
+}

--- a/src/Exception/ErrorExceptionInterface.php
+++ b/src/Exception/ErrorExceptionInterface.php
@@ -2,6 +2,9 @@
 
 namespace RREST\Exception;
 
+/**
+ * @deprecated use ErrorException instead.
+ */
 interface ErrorExceptionInterface
 {
     /**

--- a/src/Exception/InvalidJSONException.php
+++ b/src/Exception/InvalidJSONException.php
@@ -2,30 +2,14 @@
 
 namespace RREST\Exception;
 
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-
-class InvalidJSONException extends BadRequestHttpException implements ErrorExceptionInterface
+class InvalidJSONException extends ErrorException implements ErrorExceptionInterface
 {
-    /**
-     * @var \RREST\Error[]
-     */
-    public $errors;
-
     /**
      * @param \RREST\Error[] $errors   List of errors
      * @param Exception|null $previous
      */
     public function __construct(array $errors, $message = 'Invalid', \Exception $previous = null, $code = 0)
     {
-        $this->errors = $errors;
-        parent::__construct($message, $previous, $code);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getErrors()
-    {
-        return $this->errors;
+        parent::__construct($errors, 400, $message, $previous, [], $code);
     }
 }

--- a/src/Exception/InvalidParameterException.php
+++ b/src/Exception/InvalidParameterException.php
@@ -2,30 +2,14 @@
 
 namespace RREST\Exception;
 
-use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
-
-class InvalidParameterException extends UnprocessableEntityHttpException implements ErrorExceptionInterface
+class InvalidParameterException extends ErrorException implements ErrorExceptionInterface
 {
-    /**
-     * @var \RREST\Error[]
-     */
-    public $errors;
-
     /**
      * @param \RREST\Error[]  $errors   List of errors
      * @param \Exception|null $previous
      */
     public function __construct(array $errors, $message = 'Invalid', \Exception $previous = null, $code = 0)
     {
-        $this->errors = $errors;
-        parent::__construct($message, $previous, $code);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getErrors()
-    {
-        return $this->errors;
+        parent::__construct($errors, 422, $message, $previous, [], $code);
     }
 }

--- a/src/Exception/InvalidRequestPayloadBodyException.php
+++ b/src/Exception/InvalidRequestPayloadBodyException.php
@@ -2,30 +2,14 @@
 
 namespace RREST\Exception;
 
-use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
-
-class InvalidRequestPayloadBodyException extends UnprocessableEntityHttpException implements ErrorExceptionInterface
+class InvalidRequestPayloadBodyException extends ErrorException implements ErrorExceptionInterface
 {
-    /**
-     * @var \RREST\Error[]
-     */
-    public $errors;
-
     /**
      * @param \RREST\Error[]  $errors   List of errors
      * @param \Exception|null $previous
      */
     public function __construct(array $errors, $message = 'Invalid', \Exception $previous = null, $code = 0)
     {
-        $this->errors = $errors;
-        parent::__construct($message, $previous, $code);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getErrors()
-    {
-        return $this->errors;
+        parent::__construct($errors, 500, $message, $previous, [], $code);
     }
 }

--- a/src/Exception/InvalidResponsePayloadBodyException.php
+++ b/src/Exception/InvalidResponsePayloadBodyException.php
@@ -2,15 +2,8 @@
 
 namespace RREST\Exception;
 
-use Symfony\Component\HttpKernel\Exception\HttpException;
-
-class InvalidResponsePayloadBodyException extends HttpException implements ErrorExceptionInterface
+class InvalidResponsePayloadBodyException extends ErrorException implements ErrorExceptionInterface
 {
-    /**
-     * @var \RREST\Error[]
-     */
-    public $errors;
-
     /**
      * @param \RREST\Error[] $errors   List of errors
      * @param string         $message
@@ -19,15 +12,6 @@ class InvalidResponsePayloadBodyException extends HttpException implements Error
      */
     public function __construct(array $errors, $message = 'Invalid', \Exception $previous = null, $code = 0)
     {
-        $this->errors = $errors;
-        parent::__construct(500, $message, $previous, [], $code);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getErrors()
-    {
-        return $this->errors;
+        parent::__construct($errors, 500, $message, $previous, [], $code);
     }
 }

--- a/src/Exception/InvalidXMLException.php
+++ b/src/Exception/InvalidXMLException.php
@@ -3,30 +3,15 @@
 namespace RREST\Exception;
 
 use RREST\Error;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
-class InvalidXMLException extends BadRequestHttpException implements ErrorExceptionInterface
+class InvalidXMLException extends ErrorException implements ErrorExceptionInterface
 {
-    /**
-     * @var Error[]
-     */
-    public $errors;
-
     /**
      * @param Error[]         $errors   List of errors
      * @param \Exception|null $previous
      */
     public function __construct(array $errors, $message = 'Invalid', \Exception $previous = null, $code = 0)
     {
-        $this->errors = $errors;
-        parent::__construct($message, $previous, $code);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getErrors()
-    {
-        return $this->errors;
+        parent::__construct($errors, 400, $message, $previous, [], $code);
     }
 }


### PR DESCRIPTION
Deprecates the interface used to identify RREST errors and adds an abstract class to replace it.

When handling those errors downstream they were not `\Throwable` but interfaces making them complicated to manage.