### PR TITLE
fix(content): Remove flacky json_encode.

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -192,7 +192,7 @@ class Response
         $this->assertReponseSchema(
             $this->getFormat(),
             $this->getSchema(),
-            \json_encode($content)
+            $content
         );
     }
 
@@ -301,7 +301,7 @@ class Response
 
         switch (true) {
             case strpos($format, 'json') !== false:
-                $this->assertResponseJSON($value, $schema);
+                $this->assertResponseJSON(json_encode($value), $schema);
                 break;
             case strpos($format, 'xml') !== false:
                 $this->assertResponseXML($value, $schema);


### PR DESCRIPTION
Having a json encode here makes the xml validation fail.

Also it makes the validation validate a content that is not the real one.